### PR TITLE
fix(onboarding): Update frontend validation to exclude text_input

### DIFF
--- a/app/admin/onboarding/[id]/page.tsx
+++ b/app/admin/onboarding/[id]/page.tsx
@@ -320,7 +320,7 @@ function SortableQuestion({
         )}
 
         {/* Options de réponse */}
-        {question.type.kind !== 'slider' && question.type.kind !== 'circular_picker' && (
+        {question.type.kind !== 'slider' && question.type.kind !== 'circular_picker' && question.type.kind !== 'text_input' && (
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <Label>Options de réponse ({question.options.length})</Label>

--- a/app/admin/onboarding/new/page.tsx
+++ b/app/admin/onboarding/new/page.tsx
@@ -148,8 +148,8 @@ export default function NewOnboardingPage() {
         return;
       }
 
-      // Les sliders et circular pickers n'ont pas besoin d'options
-      if (q.type.kind !== 'slider' && q.type.kind !== 'circular_picker' && q.options.length === 0) {
+      // Les sliders, circular pickers et text inputs n'ont pas besoin d'options
+      if (q.type.kind !== 'slider' && q.type.kind !== 'circular_picker' && q.type.kind !== 'text_input' && q.options.length === 0) {
         toast({
           title: 'Erreur',
           description: 'Toutes les questions doivent avoir au moins une option',


### PR DESCRIPTION
## Summary
Fixes frontend validation to align with backend API (PR #50).

Text input questions (`text_input`) don't need options arrays since they are free text entry fields.

## Changes
- ✅ Updated validation in `new/page.tsx` (line 152)
- ✅ Updated conditional rendering in `[id]/page.tsx` (line 323)

## Problem
Question 8 (`q8_challenges` - text_input) was blocked from publishing due to empty options array, even though backend API was fixed in PR #50.

## Solution
Exclude `text_input` from requiring options in both admin forms:
- Creation form (`new/page.tsx`)
- Edit form (`[id]/page.tsx`)

## Testing
- [x] Text input questions can now be created/edited without options
- [x] Matches backend validation logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)