### PR TITLE
fix(onboarding): Fix validation for slider/circular_picker/text_input questions

### DIFF
--- a/app/api/admin/onboarding/[id]/route.ts
+++ b/app/api/admin/onboarding/[id]/route.ts
@@ -109,10 +109,15 @@ export async function PUT(
       // Validate questions
       for (let i = 0; i < questions.length; i++) {
         const q = questions[i];
-        if (!q.title || !q.category || !q.type || !q.options) {
+        if (!q.title || !q.category || !q.type) {
           return apiError(`Question at index ${i} is missing required fields`, 400);
         }
-        if (q.options.length === 0) {
+
+        // Sliders, circular pickers, and text inputs don't need options
+        const needsOptions = q.type.kind !== 'slider'
+          && q.type.kind !== 'circular_picker'
+          && q.type.kind !== 'text_input';
+        if (needsOptions && (!q.options || q.options.length === 0)) {
           return apiError(`Question at index ${i} must have at least one option`, 400);
         }
       }

--- a/app/api/admin/onboarding/route.ts
+++ b/app/api/admin/onboarding/route.ts
@@ -78,10 +78,15 @@ export async function POST(request: NextRequest) {
     // Validate questions structure
     for (let i = 0; i < questions.length; i++) {
       const q = questions[i];
-      if (!q.title || !q.category || !q.type || !q.options) {
+      if (!q.title || !q.category || !q.type) {
         return apiError(`Question at index ${i} is missing required fields`, 400);
       }
-      if (q.options.length === 0) {
+
+      // Sliders, circular pickers, and text inputs don't need options
+      const needsOptions = q.type.kind !== 'slider'
+        && q.type.kind !== 'circular_picker'
+        && q.type.kind !== 'text_input';
+      if (needsOptions && (!q.options || q.options.length === 0)) {
         return apiError(`Question at index ${i} must have at least one option`, 400);
       }
     }


### PR DESCRIPTION
## Summary
Apply the same validation fix from the publish endpoint to POST and PUT endpoints. This fix was already implemented in commit c6c057d for the publish endpoint, but was missing from the create and update endpoints.

## Problem
The validation logic incorrectly required ALL question types to have options arrays, but three question types don't use options:
- `slider` - Uses sliderMin/Max/Step/Unit configuration
- `circular_picker` - Uses sliderMin/Max/Step/Unit configuration  
- `text_input` - Free text entry field

This caused the error: "question at index 21 must have at least one option"

## Solution
Added conditional validation that checks the question type before requiring options:
```typescript
// Sliders, circular pickers, and text inputs don't need options
const needsOptions = q.type.kind !== 'slider'
  && q.type.kind !== 'circular_picker'
  && q.type.kind !== 'text_input';
if (needsOptions && (!q.options || q.options.length === 0)) {
  return apiError(`Question at index ${i} must have at least one option`, 400);
}
```

## Files Changed
- `app/api/admin/onboarding/route.ts` - POST endpoint validation
- `app/api/admin/onboarding/[id]/route.ts` - PUT endpoint validation

## Test Plan
- [x] Existing onboarding configs with slider/circular_picker/text_input questions can be saved without errors
- [x] Validation still correctly rejects questions that DO need options but don't have any

🤖 Generated with [Claude Code](https://claude.com/claude-code)