### PR TITLE
fix(onboarding): Add text_input to validation in publish endpoint

### DIFF
--- a/app/api/admin/onboarding/[id]/publish/route.ts
+++ b/app/api/admin/onboarding/[id]/publish/route.ts
@@ -49,8 +49,10 @@ export async function POST(
         return apiError(`Question at index ${i} is incomplete`, 400);
       }
 
-      // Sliders and circular pickers don't need options (they use sliderMin/Max/Step)
-      const needsOptions = q.type.kind !== 'slider' && q.type.kind !== 'circular_picker';
+      // Sliders, circular pickers, and text inputs don't need options
+      const needsOptions = q.type.kind !== 'slider'
+        && q.type.kind !== 'circular_picker'
+        && q.type.kind !== 'text_input';
       if (needsOptions && (!q.options || q.options.length === 0)) {
         return apiError(`Question at index ${i} must have at least one option`, 400);
       }


### PR DESCRIPTION
## Summary
Complete the validation fix for the publish endpoint by adding `text_input` to the list of question types that don't require options.

## Problem
The publish endpoint was missing `text_input` in the validation exception, causing errors when trying to publish onboarding configs with text input questions.

## Solution
Added `text_input` to the validation check alongside `slider` and `circular_picker`:

```typescript
// Sliders, circular pickers, and text inputs don't need options
const needsOptions = q.type.kind !== 'slider'
  && q.type.kind !== 'circular_picker'
  && q.type.kind !== 'text_input';
```

## Files Changed
- `app/api/admin/onboarding/[id]/publish/route.ts` - Added text_input exception

## Related
- Completes the fix started in PR #54
- All 3 endpoints (POST, PUT, publish) now have consistent validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)