### PR TITLE
fix(onboarding): Use snake_case for information_screens field

### DIFF
--- a/scripts/add-information-screens.ts
+++ b/scripts/add-information-screens.ts
@@ -279,9 +279,10 @@ async function addInformationScreens() {
     }));
 
     // Update the config with information screens
+    // Use snake_case to match Android backend schema
     await db.collection('onboarding_configs').doc(configId).update({
-      informationScreens: screensWithIds,
-      updatedAt: now,
+      information_screens: screensWithIds,
+      updated_at: now,
     });
 
     console.log(`✅ ${screensWithIds.length} écrans d'information ajoutés avec succès !`);


### PR DESCRIPTION
## Summary
Fix field name mismatch between OraWebApp (camelCase) and Android app (snake_case) for information screens.

## Problem
The `add-information-screens.ts` script was saving the field as `informationScreens` (camelCase), but the Android app expects `information_screens` (snake_case) as defined by `@PropertyName` annotations in the Kotlin models.

This caused information screens to not display in the Android app even though they were successfully saved to Firestore.

## Solution
Changed the script to use snake_case field names:
- `informationScreens` → `information_screens`
- `updatedAt` → `updated_at`

This matches the backend schema convention where all Firestore fields use snake_case.

## Files Changed
- `scripts/add-information-screens.ts` - Updated field names to snake_case

## Testing
After this fix and re-running the script:
1. Information screens will be saved with correct field names
2. Android app will successfully load and display information screens
3. Field names will match across all systems (Admin Portal, Firestore, Android)

## Related
- Companion Android PR will update the repository constant
- After merging, re-run: `npm run add-info-screens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)